### PR TITLE
fix: move router.push to useEffect to avoid React warning (#45)

### DIFF
--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -8,7 +8,7 @@
  * 3. Session summary and statistics
  */
 
-import { useReducer, useCallback, useMemo, Suspense } from 'react';
+import { useReducer, useCallback, useMemo, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import type {
   SessionConfig as SessionConfigType,
@@ -189,6 +189,14 @@ function PracticePageContent() {
     return parseUrlParams(searchParams);
   }, [searchParams]);
 
+  // Handle redirect when session becomes active
+  // Using useEffect to avoid calling router.push during render
+  useEffect(() => {
+    if (state.status === 'active') {
+      router.push('/practice/session');
+    }
+  }, [state.status, router]);
+
   // Start session and redirect to active session page
   const handleStartSession = useCallback((config: SessionConfigType) => {
     dispatch({ type: 'START_SESSION', config });
@@ -310,10 +318,8 @@ function PracticePageContent() {
     );
   }
 
-  // Active session - should have been redirected to /practice/session
-  // If we get here, redirect
-  router.push('/practice/session');
-
+  // Active session - useEffect above handles the redirect to /practice/session
+  // Show loading state while redirect is in progress
   return (
     <div className="max-w-4xl mx-auto text-center py-12">
       <div className="animate-pulse">


### PR DESCRIPTION
## Summary

- Fixes the "Cannot update a component (Router) while rendering a different component" console error
- Moves `router.push('/practice/session')` from the render phase into a `useEffect` hook
- This is the correct React pattern for navigation side effects

## Problem

The practice page was calling `router.push()` directly during render when the session status was 'active', which violates React's rules about not causing state updates during render.

## Solution

- Added `useEffect` to the React import
- Created a new `useEffect` hook that watches `state.status` and triggers the redirect when status becomes 'active'
- Removed the direct `router.push()` call from the render block
- The loading state now just displays while the redirect is in progress

## Test plan

- [x] All 410 tests pass
- [x] Lint passes with only pre-existing warnings
- [ ] Manual test: Start a practice session and verify no console warning appears

Closes #45