### PR TITLE
fix: support 'method' URL param for study page links (#28)

### DIFF
--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -130,7 +130,8 @@ function parseUrlParams(searchParams: URLSearchParams): InitialConfigValues {
   }
 
   // Parse methods parameter (comma-separated list)
-  const methodsParam = searchParams.get('methods');
+  // Also support 'method' (singular) as an alias for study page links
+  const methodsParam = searchParams.get('methods') || searchParams.get('method');
   if (methodsParam) {
     const methodNames = methodsParam.split(',').map(m => m.trim().toLowerCase());
     const validMethods: MethodName[] = [];
@@ -351,10 +352,13 @@ function PracticePageLoading() {
  * Supported URL Parameters:
  * - difficulty: beginner | intermediate | advanced | expert | mastery
  * - methods: comma-separated list (e.g., distributive,squaring,near-100)
+ * - method: single method (alias for methods, used by study page links)
  * - count: number (1-1000) or 'infinite'
  * - negatives: true | false
  *
- * Example: /practice?difficulty=intermediate&methods=squaring,distributive&count=15
+ * Examples:
+ * - /practice?difficulty=intermediate&methods=squaring,distributive&count=15
+ * - /practice?method=distributive (from study page link)
  */
 export default function PracticePage() {
   return (


### PR DESCRIPTION
## Summary

- Adds support for `?method=` (singular) URL parameter as an alias for `?methods=`
- Fixes the study-to-practice navigation flow where study pages link with `?method=distributive`

## Problem

Study pages create links like `/practice?method=distributive` but the practice page only read `?methods=` (plural), causing the method parameter to be ignored.

## Solution

Updated `parseUrlParams()` to check both `methods` and `method` parameters:
```typescript
const methodsParam = searchParams.get('methods') || searchParams.get('method');
```

## Test plan

- [x] All 410 tests pass
- [x] Lint passes with only pre-existing warnings
- [ ] Manual test: Click "Start Practice Session" from a study page and verify method is pre-selected

Closes #28
Closes #52