### PR TITLE
fix: add reduced-motion support for animations (#35)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -229,3 +229,42 @@ body {
 .animate-progress-fill {
   animation: progressFill 0.5s ease-out forwards;
 }
+
+/* Reduced motion support for accessibility (Issue #35) */
+@media (prefers-reduced-motion: reduce) {
+  /* Disable all custom animations */
+  .animate-shake,
+  .animate-fade-in,
+  .animate-slide-in-bottom,
+  .animate-slide-in-top,
+  .animate-pulse-warning,
+  .animate-scale-in,
+  .animate-count-up,
+  .animate-progress-fill {
+    animation: none;
+  }
+
+  /* Ensure elements are visible without animation */
+  .animate-fade-in,
+  .animate-slide-in-bottom,
+  .animate-slide-in-top,
+  .animate-scale-in,
+  .animate-count-up {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* Disable Tailwind's animate-pulse */
+  .animate-pulse {
+    animation: none;
+  }
+
+  /* Reduce transition durations */
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `@media (prefers-reduced-motion: reduce)` support for accessibility
- Disables all custom animations for users who prefer reduced motion
- Ensures animated elements remain visible without motion

## Changes

- Disables custom animations: shake, fade-in, slide-in, pulse-warning, scale-in, count-up, progress-fill
- Disables Tailwind's animate-pulse  
- Reduces all transition/animation durations to near-zero

## Test plan

- [x] Lint passes
- [ ] Manual test: Enable "Reduce motion" in OS accessibility settings and verify no animations

Closes #35