### PR TITLE
fix: move DOM focus to newly selected tab on keyboard navigation (#36)

### DIFF
--- a/src/app/study/[method]/page.tsx
+++ b/src/app/study/[method]/page.tsx
@@ -526,16 +526,18 @@ export default function MethodStudyPage(): React.ReactElement {
     setActiveTab(tabId);
   }, []);
 
-  // Keyboard navigation for tabs
+  // Keyboard navigation for tabs (Issue #36: Move DOM focus to new tab)
   const handleTabKeyDown = useCallback(
     (event: React.KeyboardEvent, tabId: TabId) => {
       const currentTabIndex = TABS.findIndex((t) => t.id === tabId);
+      let newTabId: TabId | undefined;
 
       if (event.key === 'ArrowRight') {
         event.preventDefault();
         const nextIndex = (currentTabIndex + 1) % TABS.length;
         const nextTab = TABS[nextIndex];
         if (nextTab) {
+          newTabId = nextTab.id;
           setActiveTab(nextTab.id);
         }
       } else if (event.key === 'ArrowLeft') {
@@ -543,8 +545,20 @@ export default function MethodStudyPage(): React.ReactElement {
         const prevIndex = (currentTabIndex - 1 + TABS.length) % TABS.length;
         const prevTab = TABS[prevIndex];
         if (prevTab) {
+          newTabId = prevTab.id;
           setActiveTab(prevTab.id);
         }
+      }
+
+      // Move DOM focus to the newly selected tab button
+      if (newTabId) {
+        // Use requestAnimationFrame to ensure DOM has updated
+        requestAnimationFrame(() => {
+          const newTabElement = document.getElementById(`tab-${newTabId}`);
+          if (newTabElement) {
+            newTabElement.focus();
+          }
+        });
       }
     },
     []


### PR DESCRIPTION
## Summary

- Fixes accessibility issue where Arrow Left/Right on tabs changed visual state but didn't move DOM focus
- Screen reader users now hear tab change announcements

## Changes

- Added focus management in `handleTabKeyDown`
- Uses `requestAnimationFrame` to ensure DOM updates before focusing
- Focus moves to newly selected tab button via its ID

## Test plan

- [x] All tests pass
- [x] Lint passes
- [ ] Manual test: Use keyboard to navigate tabs and verify focus moves

Closes #36