### PR TITLE
fix: add breadcrumb navigation to practice pages (#38)

### DIFF
--- a/src/app/practice/session/page.tsx
+++ b/src/app/practice/session/page.tsx
@@ -936,6 +936,31 @@ export default function ActiveSessionPage() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-6" role="main" aria-label="Practice session">
+      {/* Breadcrumb (Issue #38) */}
+      <nav aria-label="Breadcrumb">
+        <ol className="flex items-center gap-2 text-sm">
+          <li>
+            <Link
+              href="/"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Home
+            </Link>
+          </li>
+          <li className="text-muted-foreground">/</li>
+          <li>
+            <Link
+              href="/practice"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Practice
+            </Link>
+          </li>
+          <li className="text-muted-foreground">/</li>
+          <li className="text-foreground font-medium">Session</li>
+        </ol>
+      </nav>
+
       {/* Session Header with Controls */}
       <div className="flex flex-wrap items-center justify-between gap-4 bg-card rounded-lg shadow-md p-4">
         <div className="flex items-center gap-4">

--- a/src/components/features/practice/SessionConfig.tsx
+++ b/src/components/features/practice/SessionConfig.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { DifficultyLevel, type CustomRange } from '@/lib/types/problem';
 import { MethodName } from '@/lib/types/method';
 import type { SessionConfig as SessionConfigType } from '@/lib/types/session';
@@ -121,6 +122,22 @@ export function SessionConfig({ onStartSession, initialValues }: SessionConfigPr
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
+      {/* Breadcrumb (Issue #38) */}
+      <nav aria-label="Breadcrumb">
+        <ol className="flex items-center gap-2 text-sm">
+          <li>
+            <Link
+              href="/"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Home
+            </Link>
+          </li>
+          <li className="text-muted-foreground">/</li>
+          <li className="text-foreground font-medium">Practice</li>
+        </ol>
+      </nav>
+
       {/* Header */}
       <div className="text-center space-y-2">
         <h1 className="text-3xl font-bold text-foreground">


### PR DESCRIPTION
## Summary

- Adds breadcrumb navigation to practice configuration page (Home / Practice)
- Adds breadcrumb navigation to practice session page (Home / Practice / Session)
- Matches breadcrumb pattern used in study pages for consistency

## Changes

- `SessionConfig.tsx`: Added breadcrumb nav before header
- `session/page.tsx`: Added breadcrumb nav before session header

## Test plan

- [x] All tests pass
- [x] Lint passes
- [ ] Manual test: Navigate to practice pages and verify breadcrumbs appear

Closes #38