### PR TITLE
feat: add full place-value decomposition for 3+ digit numbers (#33)

### DIFF
--- a/src/lib/core/methods/base-method.ts
+++ b/src/lib/core/methods/base-method.ts
@@ -121,6 +121,47 @@ export abstract class BaseMethod {
   }
 
   /**
+   * Helper: Get full place-value decomposition for any number.
+   * Breaks number into individual place values (ones, tens, hundreds, etc.)
+   *
+   * @param n - Number to decompose (uses absolute value)
+   * @returns Array of place values from largest to smallest, excluding zeros
+   *
+   * @example
+   * ```typescript
+   * decomposeFullPlaceValue(347)  // returns [300, 40, 7]
+   * decomposeFullPlaceValue(1005) // returns [1000, 5]
+   * decomposeFullPlaceValue(50)   // returns [50]
+   * decomposeFullPlaceValue(7)    // returns [7]
+   * ```
+   */
+  protected decomposeFullPlaceValue(n: number): number[] {
+    const absN = Math.abs(n);
+    if (absN === 0) return [0];
+
+    const parts: number[] = [];
+    let remaining = absN;
+    let placeValue = 1;
+
+    // Find the highest place value
+    while (placeValue * 10 <= remaining) {
+      placeValue *= 10;
+    }
+
+    // Extract each place value
+    while (placeValue >= 1) {
+      const digit = Math.floor(remaining / placeValue);
+      if (digit > 0) {
+        parts.push(digit * placeValue);
+        remaining -= digit * placeValue;
+      }
+      placeValue = Math.floor(placeValue / 10);
+    }
+
+    return parts.length > 0 ? parts : [0];
+  }
+
+  /**
    * Helper: Find the nearest round number (multiple of 10).
    *
    * @param n - Number to find nearest round for


### PR DESCRIPTION
## Summary

- Adds `decomposeFullPlaceValue()` helper method to `BaseMethod` for breaking down numbers into individual place values (e.g., 347 → [300, 40, 7])
- Introduces 'multi-additive' partition type for 3+ digit numbers in the distributive method
- Updates solution generation to show clearer step-by-step decomposition for larger numbers

## Changes

| File | Change |
|------|--------|
| `base-method.ts` | New `decomposeFullPlaceValue()` helper (+41 lines) |
| `distributive.ts` | Multi-additive partition support (+91/-38 lines) |

## Example

For 347 × 8, instead of:
- (340 + 7) × 8

Now shows:
- (300 + 40 + 7) × 8 = 300×8 + 40×8 + 7×8

This makes the place-value structure more explicit and educational.

## Test plan

- [x] All 410 existing tests pass
- [x] Multi-additive partitions generate valid expressions
- [x] Validator accepts all generated solutions

Closes #33