### PR TITLE
fix: improve mobile touch targets and keyboard visibility (#66)

### DIFF
--- a/src/app/practice/session/page.tsx
+++ b/src/app/practice/session/page.tsx
@@ -981,10 +981,10 @@ export default function ActiveSessionPage() {
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Keyboard Shortcuts Help Button */}
+          {/* Keyboard Shortcuts Help Button - hidden on mobile */}
           <button
             onClick={handleToggleShortcutHelp}
-            className="p-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+            className="hidden md:flex p-2 min-h-[44px] min-w-[44px] items-center justify-center rounded-lg bg-muted hover:bg-muted/80 transition-colors"
             aria-label="Keyboard shortcuts"
             title="Keyboard shortcuts (?)"
           >
@@ -996,7 +996,7 @@ export default function ActiveSessionPage() {
           {/* Pause Button */}
           <button
             onClick={handleTogglePause}
-            className="p-2 rounded-lg bg-muted hover:bg-muted/80 transition-colors"
+            className="flex p-2 min-h-[44px] min-w-[44px] items-center justify-center rounded-lg bg-muted hover:bg-muted/80 transition-colors"
             aria-label={state.phase === 'paused' ? 'Resume session (Space)' : 'Pause session (Space)'}
             title={state.phase === 'paused' ? 'Resume (Space)' : 'Pause (Space)'}
           >
@@ -1015,7 +1015,7 @@ export default function ActiveSessionPage() {
           {/* End Session Button */}
           <button
             onClick={handleEndSession}
-            className="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+            className="px-4 py-2 min-h-[44px] text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
             title="End session (Q)"
           >
             End Session
@@ -1136,8 +1136,8 @@ export default function ActiveSessionPage() {
             resetKey={state.currentProblem?.id}
           />
 
-          {/* Keyboard shortcuts hint */}
-          <div className="text-center text-sm text-muted-foreground">
+          {/* Keyboard shortcuts hint - hidden on mobile */}
+          <div className="hidden text-center text-sm text-muted-foreground md:block">
             Press <KeyboardShortcut keys={['?']} size="sm" /> for keyboard shortcuts
           </div>
         </div>

--- a/src/components/features/practice/AnswerInput.tsx
+++ b/src/components/features/practice/AnswerInput.tsx
@@ -94,12 +94,20 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
       getValue: () => value
     }));
 
-    // Auto-focus on mount
+    // Auto-focus on mount and scroll into view on mobile
     useEffect(() => {
       if (autoFocus && inputRef.current) {
         inputRef.current.focus();
       }
     }, [autoFocus]);
+
+    // Handle focus event to scroll input into view on mobile when keyboard opens
+    const handleFocus = () => {
+      // Use a small delay to allow keyboard to open first
+      setTimeout(() => {
+        inputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 300);
+    };
 
     // Track previous resetKey to detect changes and reset value
     const prevResetKeyRef = useRef(resetKey);
@@ -213,9 +221,11 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
             ref={inputRef}
             type="text"
             inputMode="numeric"
+            enterKeyHint="send"
             value={value}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
             disabled={disabled}
             placeholder={placeholder}
             aria-label="Your answer"
@@ -231,7 +241,7 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
             <button
               type="button"
               onClick={handleClear}
-              className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+              className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
               aria-label="Clear input"
             >
               <svg
@@ -259,7 +269,7 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
         <button
           onClick={(e) => handleSubmit(e as unknown as FormEvent)}
           disabled={!canSubmit}
-          className="rounded-xl bg-gradient-to-r from-primary to-primary/90 px-6 py-4 font-semibold text-primary-foreground shadow-lg transition-all duration-200 hover:from-primary/90 hover:to-primary/80 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-ring/50 disabled:cursor-not-allowed disabled:from-muted disabled:to-muted disabled:opacity-50 disabled:shadow-none sm:col-span-2 lg:col-span-2"
+          className="rounded-xl bg-gradient-to-r from-primary to-primary/90 px-6 py-4 min-h-[44px] font-semibold text-primary-foreground shadow-lg transition-all duration-200 hover:from-primary/90 hover:to-primary/80 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-ring/50 disabled:cursor-not-allowed disabled:from-muted disabled:to-muted disabled:opacity-50 disabled:shadow-none sm:col-span-2 lg:col-span-2"
           aria-label="Submit answer"
         >
           <span className="flex items-center justify-center gap-2">
@@ -286,7 +296,7 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
           <button
             onClick={handleHintRequest}
             disabled={disabled}
-            className="rounded-xl border-2 border-purple-500/30 bg-purple-500/10 px-6 py-4 font-semibold text-purple-300 transition-all duration-200 hover:border-purple-500/50 hover:bg-purple-500/20 focus:outline-none focus:ring-4 focus:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-xl border-2 border-purple-500/30 bg-purple-500/10 px-6 py-4 min-h-[44px] font-semibold text-purple-300 transition-all duration-200 hover:border-purple-500/50 hover:bg-purple-500/20 focus:outline-none focus:ring-4 focus:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label={`Request hint (${hintsUsed} used)`}
           >
             <span className="flex items-center justify-center gap-2">
@@ -317,7 +327,7 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
           <button
             onClick={onSkip}
             disabled={disabled}
-            className="rounded-xl border-2 border-border bg-muted/50 px-6 py-4 font-semibold text-muted-foreground transition-all duration-200 hover:border-muted-foreground hover:bg-muted focus:outline-none focus:ring-4 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-xl border-2 border-border bg-muted/50 px-6 py-4 min-h-[44px] font-semibold text-muted-foreground transition-all duration-200 hover:border-muted-foreground hover:bg-muted focus:outline-none focus:ring-4 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Skip this problem"
           >
             <span className="flex items-center justify-center gap-2">
@@ -341,8 +351,8 @@ export const AnswerInput = forwardRef<AnswerInputHandle, AnswerInputProps>(
         )}
       </div>
 
-      {/* Keyboard hint */}
-      <p className="text-center text-sm text-muted-foreground">
+      {/* Keyboard hint - hidden on mobile */}
+      <p className="hidden text-center text-sm text-muted-foreground md:block">
         Press <kbd className="rounded bg-muted px-2 py-1 font-mono text-xs">Enter</kbd> to submit
       </p>
     </div>

--- a/src/components/features/practice/FeedbackDisplay.tsx
+++ b/src/components/features/practice/FeedbackDisplay.tsx
@@ -204,7 +204,7 @@ export const FeedbackDisplay = memo(function FeedbackDisplay({
           ref={viewSolutionButtonRef}
           onClick={onViewSolution}
           disabled={disableViewSolution}
-          className="rounded-xl border-2 border-purple-500/30 bg-purple-500/10 px-6 py-4 font-semibold text-purple-300 transition-all duration-200 hover:border-purple-500/50 hover:bg-purple-500/20 focus:outline-none focus:ring-4 focus:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-xl border-2 border-purple-500/30 bg-purple-500/10 px-6 py-4 min-h-[44px] font-semibold text-purple-300 transition-all duration-200 hover:border-purple-500/50 hover:bg-purple-500/20 focus:outline-none focus:ring-4 focus:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="View solution walkthrough (Press S)"
         >
           <span className="flex items-center justify-center gap-2">
@@ -229,7 +229,7 @@ export const FeedbackDisplay = memo(function FeedbackDisplay({
         <button
           ref={nextButtonRef}
           onClick={onNext}
-          className="rounded-xl bg-gradient-to-r from-blue-600 to-blue-500 px-6 py-4 font-semibold text-white shadow-lg transition-all duration-200 hover:from-blue-500 hover:to-blue-400 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-blue-500/50"
+          className="rounded-xl bg-gradient-to-r from-blue-600 to-blue-500 px-6 py-4 min-h-[44px] font-semibold text-white shadow-lg transition-all duration-200 hover:from-blue-500 hover:to-blue-400 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-blue-500/50"
           aria-label="Next problem (Press N)"
         >
           <span className="flex items-center justify-center gap-2">

--- a/src/components/features/practice/SolutionWalkthrough.tsx
+++ b/src/components/features/practice/SolutionWalkthrough.tsx
@@ -153,7 +153,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
             <button
               ref={closeButtonRef}
               onClick={onClose}
-              className="p-2 rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+              className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
               aria-label="Close walkthrough (Press Escape or N for next problem)"
             >
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -187,7 +187,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
             <button
               onClick={goToPreviousStep}
               disabled={currentStepIndex === 0 || showAllSteps}
-              className="px-4 py-2 rounded-lg bg-secondary text-secondary-foreground font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-secondary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+              className="px-4 py-2 min-h-[44px] rounded-lg bg-secondary text-secondary-foreground font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-secondary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
             >
               <span className="flex items-center gap-2">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -206,7 +206,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
             <button
               onClick={goToNextStep}
               disabled={currentStepIndex === totalSteps - 1 || showAllSteps}
-              className="px-4 py-2 rounded-lg bg-secondary text-secondary-foreground font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-secondary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+              className="px-4 py-2 min-h-[44px] rounded-lg bg-secondary text-secondary-foreground font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-secondary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
             >
               <span className="flex items-center gap-2">
                 Next
@@ -221,7 +221,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
           <div className="flex items-center gap-2">
             <button
               onClick={toggleShowAll}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent ${
+              className={`px-4 py-2 min-h-[44px] rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent ${
                 showAllSteps
                   ? 'bg-accent text-accent-foreground'
                   : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
@@ -233,7 +233,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
             <button
               onClick={toggleAutoAdvance}
               disabled={showAllSteps}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 disabled:cursor-not-allowed ${
+              className={`px-4 py-2 min-h-[44px] rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 disabled:cursor-not-allowed ${
                 autoAdvance
                   ? 'bg-accent text-accent-foreground'
                   : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
@@ -312,7 +312,7 @@ export const SolutionWalkthrough = memo(function SolutionWalkthrough({
         <div className="mb-6">
           <button
             onClick={() => setShowComparison(!showComparison)}
-            className="w-full px-6 py-4 bg-card border border-border rounded-lg hover:bg-muted/30 transition-colors focus:outline-none focus:ring-2 focus:ring-accent flex items-center justify-between"
+            className="w-full px-6 py-4 min-h-[44px] bg-card border border-border rounded-lg hover:bg-muted/30 transition-colors focus:outline-none focus:ring-2 focus:ring-accent flex items-center justify-between"
           >
             <span className="text-lg font-semibold text-foreground">
               Compare with Alternative Methods

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -144,7 +144,7 @@ export function Header() {
           <button
             ref={menuButtonRef}
             type="button"
-            className="md:hidden inline-flex items-center justify-center p-2 rounded-md text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-inset focus:ring-ring"
+            className="md:hidden inline-flex items-center justify-center min-h-[44px] min-w-[44px] p-2 rounded-md text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-inset focus:ring-ring"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-expanded={mobileMenuOpen}
             aria-controls="mobile-menu"
@@ -183,7 +183,7 @@ export function Header() {
                 href={href}
                 aria-current={isActive(href) ? 'page' : undefined}
                 className={`
-                  block px-4 py-2 rounded-md text-base font-medium transition-colors
+                  block px-4 py-3 min-h-[44px] rounded-md text-base font-medium transition-colors
                   ${
                     isActive(href)
                       ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-100'

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -60,9 +60,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     };
 
     const sizeStyles: Record<ButtonSize, string> = {
-      sm: 'h-9 px-3 text-sm',
-      md: 'h-10 px-4 py-2',
-      lg: 'h-11 px-8 text-lg'
+      sm: 'min-h-[44px] h-9 px-3 text-sm',
+      md: 'min-h-[44px] h-10 px-4 py-2',
+      lg: 'min-h-[44px] h-11 px-8 text-lg'
     };
 
     const combinedClassName = `${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`.trim();


### PR DESCRIPTION
## Summary
- Add minimum 44x44px touch targets to all interactive elements for WCAG compliance
- Add `enterKeyHint="send"` to answer input for better mobile keyboard experience  
- Add scroll-into-view when answer input focuses to keep problem visible when keyboard opens
- Hide keyboard shortcuts hints on mobile devices (only shown on md: breakpoint and above)
- Update Header menu button and mobile navigation links with proper touch targets

## Changes Made
- `src/components/ui/button.tsx` - Add `min-h-[44px]` to all button sizes
- `src/components/features/practice/AnswerInput.tsx` - Add touch targets, enterKeyHint, scroll-into-view on focus, hide keyboard hint on mobile
- `src/components/layout/Header.tsx` - Add 44px min touch targets to mobile menu button and nav links
- `src/app/practice/session/page.tsx` - Add touch targets to session control buttons, hide keyboard shortcuts button on mobile
- `src/components/features/practice/FeedbackDisplay.tsx` - Add touch targets to action buttons
- `src/components/features/practice/SolutionWalkthrough.tsx` - Add touch targets to all navigation buttons

## Test Plan
- [ ] Verify all buttons have at least 44x44px touch targets on mobile
- [ ] Test answer input keyboard behavior with enterKeyHint="send" on mobile
- [ ] Verify problem remains visible when keyboard opens (scroll-into-view)
- [ ] Confirm keyboard shortcuts hints are hidden on mobile
- [ ] Test navigation menu touch targets on mobile

Closes #66