### PR TITLE
feat: add method comparison and combining techniques chapters (#23)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mental-math-temp",
+  "name": "mental-math-trainer",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mental-math-temp",
+      "name": "mental-math-trainer",
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.1",
@@ -16,6 +16,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2445,6 +2446,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/study/combining/__tests__/page.test.tsx
+++ b/src/app/study/combining/__tests__/page.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CombiningTechniquesPage from '../page';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}));
+
+describe('CombiningTechniquesPage', () => {
+  describe('page structure', () => {
+    it('should render the page title', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', {
+          name: /combining calculation techniques/i
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('should render breadcrumb navigation', () => {
+      render(<CombiningTechniquesPage />);
+
+      const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+      expect(nav).toBeInTheDocument();
+      expect(within(nav).getByText('Study')).toBeInTheDocument();
+      expect(within(nav).getByText('Combining Techniques')).toBeInTheDocument();
+    });
+
+    it('should have a link back to study page in breadcrumb', () => {
+      render(<CombiningTechniquesPage />);
+
+      const studyLink = screen.getByRole('link', { name: /study/i });
+      expect(studyLink).toHaveAttribute('href', '/study');
+    });
+
+    it('should display Advanced badge', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(screen.getByText('Advanced')).toBeInTheDocument();
+    });
+  });
+
+  describe('when to combine section', () => {
+    it('should render the when to combine section', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /when to combine methods/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display combination patterns', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByText(/large numbers with structure/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/near-round with adjustment/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/symmetric requiring squaring/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/multi-step factorization/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('common combinations section', () => {
+    it('should render the common combinations section', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /common method combinations/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display combination strategies', () => {
+      render(<CombiningTechniquesPage />);
+
+      // These are rendered as card titles
+      expect(
+        screen.getByRole('heading', { name: /factorization \+ distributive/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /near power of 10 \+ simple multiplication/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /difference of squares \+ squaring/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /near 100 \+ cross multiplication/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should show when to use and process for each combination', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(screen.getAllByText(/when to use/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Process').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('worked examples section', () => {
+    it('should render the worked examples section', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /detailed worked examples/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display example problems', () => {
+      render(<CombiningTechniquesPage />);
+
+      // Check for example problems - use getAllByText since they appear in multiple places
+      expect(screen.getAllByText(/48 x 52/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/125 x 32/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/97 x 54/i).length).toBeGreaterThan(0);
+    });
+
+    it('should show expandable example cards', async () => {
+      const user = userEvent.setup();
+      render(<CombiningTechniquesPage />);
+
+      // First example should be expanded by default
+      const exampleButton = screen.getByRole('button', { name: /48 x 52/i });
+      expect(exampleButton).toHaveAttribute('aria-expanded', 'true');
+
+      // Click to collapse
+      await user.click(exampleButton);
+      expect(exampleButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should display step-by-step solutions when expanded', () => {
+      render(<CombiningTechniquesPage />);
+
+      // First example is expanded by default - check for step headings
+      expect(screen.getByRole('heading', { name: /recognize the symmetric pattern/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /apply difference of squares formula/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should show key insight for each example', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(screen.getByText(/key insight/i)).toBeInTheDocument();
+    });
+
+    it('should display method badges for combined methods', () => {
+      render(<CombiningTechniquesPage />);
+
+      // Method badges appear multiple times - use getAllByText
+      expect(screen.getAllByText(/difference of squares/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/mental squaring/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('mental strategies section', () => {
+    it('should render the mental strategies section', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /mental strategies for combining/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display strategy tips', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByText(/always scan for patterns first/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/know your anchor facts/i)).toBeInTheDocument();
+      expect(screen.getByText(/chain small steps/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/validate intermediate results/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/practice method transitions/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('practice exercises section', () => {
+    it('should render the practice exercises section', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /practice combining methods/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display practice problems', () => {
+      render(<CombiningTechniquesPage />);
+
+      expect(screen.getByText(/96 x 104/i)).toBeInTheDocument();
+      expect(screen.getByText(/45 x 88/i)).toBeInTheDocument();
+      expect(screen.getByText(/67 x 73/i)).toBeInTheDocument();
+    });
+
+    it('should have show hint buttons', () => {
+      render(<CombiningTechniquesPage />);
+
+      const hintButtons = screen.getAllByText(/show hint/i);
+      expect(hintButtons.length).toBeGreaterThan(0);
+    });
+
+    it('should toggle hint visibility', async () => {
+      const user = userEvent.setup();
+      render(<CombiningTechniquesPage />);
+
+      const hintButtons = screen.getAllByText(/show hint/i);
+      const firstHintButton = hintButtons[0];
+
+      // Initially no hint visible for first exercise
+      expect(firstHintButton).toHaveTextContent(/show hint/i);
+
+      // Click to show hint
+      await user.click(firstHintButton);
+      expect(firstHintButton).toHaveTextContent(/hide hint/i);
+
+      // Click to hide hint
+      await user.click(firstHintButton);
+      expect(firstHintButton).toHaveTextContent(/show hint/i);
+    });
+
+    it('should have show answer buttons', () => {
+      render(<CombiningTechniquesPage />);
+
+      const answerButtons = screen.getAllByText(/show answer/i);
+      expect(answerButtons.length).toBeGreaterThan(0);
+    });
+
+    it('should toggle answer visibility', async () => {
+      const user = userEvent.setup();
+      render(<CombiningTechniquesPage />);
+
+      const answerButtons = screen.getAllByText(/show answer/i);
+      const firstAnswerButton = answerButtons[0];
+
+      // Click to show answer
+      await user.click(firstAnswerButton);
+      expect(firstAnswerButton).toHaveTextContent(/hide answer/i);
+
+      // Should display the answer - shown as "Answer: 9984"
+      expect(screen.getByText(/answer: 9984/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('navigation', () => {
+    it('should have link to compare methods page', () => {
+      render(<CombiningTechniquesPage />);
+
+      const compareLink = screen.getByRole('link', {
+        name: /compare individual methods/i
+      });
+      expect(compareLink).toHaveAttribute('href', '/study/compare');
+    });
+
+    it('should have link to practice page', () => {
+      render(<CombiningTechniquesPage />);
+
+      const practiceLink = screen.getByRole('link', {
+        name: /practice mixed problems/i
+      });
+      expect(practiceLink).toHaveAttribute('href', '/practice');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper heading hierarchy', () => {
+      render(<CombiningTechniquesPage />);
+
+      const h1 = screen.getByRole('heading', { level: 1 });
+      expect(h1).toHaveTextContent(/combining calculation techniques/i);
+
+      const h2s = screen.getAllByRole('heading', { level: 2 });
+      expect(h2s.length).toBeGreaterThan(0);
+    });
+
+    it('should have accessible expand/collapse buttons', async () => {
+      const user = userEvent.setup();
+      render(<CombiningTechniquesPage />);
+
+      const exampleButton = screen.getByRole('button', { name: /48 x 52/i });
+
+      // Should have aria-expanded
+      expect(exampleButton).toHaveAttribute('aria-expanded');
+
+      // Should be keyboard accessible
+      exampleButton.focus();
+      expect(document.activeElement).toBe(exampleButton);
+
+      await user.keyboard('{Enter}');
+      expect(exampleButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should have accessible hint and answer toggle buttons', () => {
+      render(<CombiningTechniquesPage />);
+
+      const buttons = screen.getAllByRole('button');
+      // All buttons should have accessible text
+      buttons.forEach((button) => {
+        expect(button.textContent?.trim().length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('mathematical correctness', () => {
+    it('should display correct answers for practice problems', async () => {
+      const user = userEvent.setup();
+      render(<CombiningTechniquesPage />);
+
+      // Show all answers
+      const answerButtons = screen.getAllByText(/show answer/i);
+
+      // Check first few problems have correct answers (format: "Answer: X")
+      await user.click(answerButtons[0]); // 96 x 104
+      expect(screen.getByText(/answer: 9984/i)).toBeInTheDocument();
+
+      await user.click(answerButtons[1]); // 45 x 88
+      expect(screen.getByText(/answer: 3960/i)).toBeInTheDocument();
+
+      await user.click(answerButtons[2]); // 67 x 73
+      expect(screen.getByText(/answer: 4891/i)).toBeInTheDocument();
+    });
+
+    it('should display correct answers for worked examples', () => {
+      render(<CombiningTechniquesPage />);
+
+      // Check worked example answers - these appear as "= XXXX" in the headers
+      expect(screen.getByText(/= 2496/)).toBeInTheDocument(); // 48 x 52
+      expect(screen.getByText(/= 4000/)).toBeInTheDocument(); // 125 x 32
+      expect(screen.getByText(/= 5238/)).toBeInTheDocument(); // 97 x 54
+    });
+  });
+});

--- a/src/app/study/compare/__tests__/page.test.tsx
+++ b/src/app/study/compare/__tests__/page.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MethodComparisonPage from '../page';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}));
+
+describe('MethodComparisonPage', () => {
+  describe('page structure', () => {
+    it('should render the page title', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /compare calculation methods/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should render breadcrumb navigation', () => {
+      render(<MethodComparisonPage />);
+
+      const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+      expect(nav).toBeInTheDocument();
+      expect(within(nav).getByText('Study')).toBeInTheDocument();
+      expect(within(nav).getByText('Compare Methods')).toBeInTheDocument();
+    });
+
+    it('should have a link back to study page in breadcrumb', () => {
+      render(<MethodComparisonPage />);
+
+      const studyLink = screen.getByRole('link', { name: /study/i });
+      expect(studyLink).toHaveAttribute('href', '/study');
+    });
+  });
+
+  describe('comparison table', () => {
+    it('should render the comparison table section', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /method comparison table/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display all six methods in the table', () => {
+      render(<MethodComparisonPage />);
+
+      const methodNames = [
+        'Distributive Property',
+        'Difference of Squares',
+        'Near Powers of 10',
+        'Squaring',
+        'Near 100',
+        'Factorization'
+      ];
+
+      // Use getAllByText since method names appear multiple times on the page
+      methodNames.forEach((name) => {
+        expect(screen.getAllByText(name).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should display table headers', () => {
+      render(<MethodComparisonPage />);
+
+      expect(screen.getByText('Method')).toBeInTheDocument();
+      expect(screen.getByText('Best For')).toBeInTheDocument();
+      expect(screen.getByText('Complexity')).toBeInTheDocument();
+      expect(screen.getByText('Speed')).toBeInTheDocument();
+      expect(screen.getByText('Example')).toBeInTheDocument();
+    });
+
+    it('should link each method to its study page', () => {
+      render(<MethodComparisonPage />);
+
+      const distributiveLink = screen.getByRole('link', {
+        name: /distributive property/i
+      });
+      expect(distributiveLink).toHaveAttribute('href', '/study/distributive');
+    });
+
+    it('should display speed badges', () => {
+      render(<MethodComparisonPage />);
+
+      const fastBadges = screen.getAllByText('Fast');
+      expect(fastBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('decision flowchart', () => {
+    it('should render the decision flowchart section', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /method selection flowchart/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should render usage instructions', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByText(/how to use this flowchart/i)
+      ).toBeInTheDocument();
+    });
+
+    it('should render mobile-friendly simplified list', () => {
+      render(<MethodComparisonPage />);
+
+      // The simplified mobile view should have ordered instructions
+      expect(screen.getByText(/squaring:/i)).toBeInTheDocument();
+      expect(screen.getByText(/difference of squares:/i)).toBeInTheDocument();
+      expect(screen.getByText(/near power of 10:/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('method vs method comparisons', () => {
+    it('should render the method vs method section', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /method vs method comparisons/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display comparison cards', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByText(/difference of squares vs near 100/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/distributive vs factorization/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/squaring vs difference of squares/i)).toBeInTheDocument();
+    });
+
+    it('should show win scenarios for each method', () => {
+      render(<MethodComparisonPage />);
+
+      const winBadges = screen.getAllByText(/wins/i);
+      expect(winBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('same problem different methods', () => {
+    it('should render the section', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /same problem, different methods/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display expandable problem cards', async () => {
+      const user = userEvent.setup();
+      render(<MethodComparisonPage />);
+
+      // Find a problem card button
+      const problemButton = screen.getByRole('button', {
+        name: /48 x 52/i
+      });
+      expect(problemButton).toBeInTheDocument();
+
+      // Click to expand
+      await user.click(problemButton);
+
+      // Should show solution details
+      expect(screen.getByText(/difference of squares \(optimal\)/i)).toBeInTheDocument();
+    });
+
+    it('should toggle expansion state on click', async () => {
+      const user = userEvent.setup();
+      render(<MethodComparisonPage />);
+
+      const problemButton = screen.getByRole('button', {
+        name: /48 x 52/i
+      });
+
+      // Initially collapsed
+      expect(problemButton).toHaveAttribute('aria-expanded', 'false');
+
+      // Expand
+      await user.click(problemButton);
+      expect(problemButton).toHaveAttribute('aria-expanded', 'true');
+
+      // Collapse
+      await user.click(problemButton);
+      expect(problemButton).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('quick pattern reference', () => {
+    it('should render the quick reference section', () => {
+      render(<MethodComparisonPage />);
+
+      expect(
+        screen.getByRole('heading', { name: /quick pattern reference/i })
+      ).toBeInTheDocument();
+    });
+
+    it('should display pattern tips', () => {
+      render(<MethodComparisonPage />);
+
+      expect(screen.getByText(/numbers ending in 5/i)).toBeInTheDocument();
+      expect(screen.getByText(/one number is 11/i)).toBeInTheDocument();
+      expect(screen.getByText(/numbers summing to 100/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('navigation', () => {
+    it('should have link to combining techniques page', () => {
+      render(<MethodComparisonPage />);
+
+      const combiningLink = screen.getByRole('link', {
+        name: /learn to combine methods/i
+      });
+      expect(combiningLink).toHaveAttribute('href', '/study/combining');
+    });
+
+    it('should have link to practice page', () => {
+      render(<MethodComparisonPage />);
+
+      const practiceLink = screen.getByRole('link', {
+        name: /practice with problems/i
+      });
+      expect(practiceLink).toHaveAttribute('href', '/practice');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper heading hierarchy', () => {
+      render(<MethodComparisonPage />);
+
+      const h1 = screen.getByRole('heading', { level: 1 });
+      expect(h1).toHaveTextContent(/compare calculation methods/i);
+
+      const h2s = screen.getAllByRole('heading', { level: 2 });
+      expect(h2s.length).toBeGreaterThan(0);
+    });
+
+    it('should have accessible complexity star ratings', () => {
+      render(<MethodComparisonPage />);
+
+      // Look for aria-label on complexity ratings
+      const complexityRatings = screen.getAllByLabelText(/complexity: \d out of 5/i);
+      expect(complexityRatings.length).toBeGreaterThan(0);
+    });
+
+    it('should have keyboard accessible expand buttons', async () => {
+      const user = userEvent.setup();
+      render(<MethodComparisonPage />);
+
+      const problemButton = screen.getByRole('button', {
+        name: /48 x 52/i
+      });
+
+      // Focus the button
+      problemButton.focus();
+      expect(document.activeElement).toBe(problemButton);
+
+      // Press Enter to activate
+      await user.keyboard('{Enter}');
+      expect(problemButton).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds comprehensive test coverage for the Method Comparison (`/study/compare`) and Combining Techniques (`/study/combining`) pages
- The pages themselves were already implemented in previous commits; this PR adds the missing test suite

## Features Tested

### Method Comparison Page (`/study/compare`)
- Page structure with proper heading hierarchy
- Breadcrumb navigation with link back to Study
- Comparison table displaying all six methods with:
  - Method names linked to individual study pages
  - "Best For" descriptions
  - Complexity star ratings (accessible)
  - Speed badges (Fast/Medium/Variable)
  - Example problems
- Decision flowchart (desktop and mobile views)
- Method vs Method comparisons with win scenarios
- Same Problem Different Methods section with expandable cards
- Quick Pattern Reference section

### Combining Techniques Page (`/study/combining`)
- Page structure with Advanced badge
- Breadcrumb navigation
- "When to Combine" section with pattern recognition
- Common Combinations section with process explanations
- Worked Examples with:
  - Expandable step-by-step solutions
  - Method badges for combined techniques
  - Key insights
- Mental Strategies section
- Practice Exercises with:
  - Show/Hide hint toggles
  - Show/Hide answer toggles
- Mathematical correctness verification

### Accessibility Coverage
- Proper heading hierarchy (h1, h2, h3)
- ARIA attributes for expand/collapse buttons
- Keyboard navigation support
- Accessible complexity star ratings with aria-labels

## Test Plan
- [x] All 54 new tests pass
- [x] Full test suite passes (613 tests)
- [x] Linting passes (no new errors)
- [x] Added @testing-library/user-event for interactive testing

## Related Issue
Closes #23