### PR TITLE
feat: add method recommendations based on user weaknesses (#71)

### DIFF
--- a/src/components/features/practice/MethodRecommendations.tsx
+++ b/src/components/features/practice/MethodRecommendations.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+/**
+ * MethodRecommendations - Displays personalized method recommendations
+ * based on user statistics analysis.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { getUserStatistics } from '@/lib/storage/statistics-store';
+import {
+  analyzeMethodProficiency,
+  type MethodAnalysisResult,
+  type MethodRecommendation,
+} from '@/lib/core/analysis';
+import { MethodName } from '@/lib/types/method';
+import type { UserStatistics } from '@/lib/types/statistics';
+
+/**
+ * Props for the MethodRecommendations component.
+ */
+interface MethodRecommendationsProps {
+  /** Callback when a recommendation is selected for focused practice */
+  onSelectMethod: (method: MethodName) => void;
+  /** Optional className for styling */
+  className?: string;
+}
+
+/**
+ * Get the color class for a proficiency score.
+ */
+function getProficiencyColor(score: number): string {
+  if (score >= 80) return 'text-success';
+  if (score >= 60) return 'text-warning';
+  return 'text-error';
+}
+
+/**
+ * Get the background color class for a proficiency bar.
+ */
+function getProficiencyBarColor(score: number): string {
+  if (score >= 80) return 'bg-success';
+  if (score >= 60) return 'bg-warning';
+  return 'bg-error';
+}
+
+/**
+ * Get the badge variant for a recommendation reason.
+ */
+function getReasonBadgeVariant(
+  reason: string
+): 'default' | 'success' | 'warning' | 'error' | 'info' {
+  if (reason.includes('Declining')) return 'error';
+  if (reason.includes('Low Accuracy')) return 'warning';
+  if (reason.includes('Speed')) return 'info';
+  if (reason.includes('Not Yet')) return 'default';
+  return 'warning';
+}
+
+/**
+ * Single recommendation card component.
+ */
+function RecommendationCard({
+  recommendation,
+  onSelect,
+}: {
+  recommendation: MethodRecommendation;
+  onSelect: (method: MethodName) => void;
+}) {
+  const { method, displayName, reason, explanation, proficiency, priority } = recommendation;
+
+  return (
+    <button
+      onClick={() => onSelect(method)}
+      className="w-full text-left p-4 rounded-lg border-2 border-border bg-card hover:border-primary
+                 hover:shadow-md transition-all focus:outline-none focus:ring-2 focus:ring-ring
+                 focus:ring-offset-2 focus:ring-offset-background group"
+      aria-label={`Practice ${displayName}. ${reason}: ${explanation}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className="text-xs font-bold text-muted-foreground"
+              aria-label={`Priority ${priority}`}
+            >
+              #{priority}
+            </span>
+            <h4 className="font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+              {displayName}
+            </h4>
+          </div>
+          <Badge variant={getReasonBadgeVariant(reason)} className="mb-2">
+            {reason}
+          </Badge>
+          <p className="text-sm text-muted-foreground">{explanation}</p>
+        </div>
+        <div className="flex-shrink-0 w-16 text-center">
+          {proficiency.hasReliableData ? (
+            <>
+              <div
+                className={`text-2xl font-bold ${getProficiencyColor(proficiency.overallScore)}`}
+              >
+                {proficiency.overallScore}
+              </div>
+              <div className="text-xs text-muted-foreground">score</div>
+            </>
+          ) : (
+            <>
+              <div className="text-2xl font-bold text-muted-foreground">--</div>
+              <div className="text-xs text-muted-foreground">no data</div>
+            </>
+          )}
+        </div>
+      </div>
+      {proficiency.hasReliableData && (
+        <div className="mt-3 pt-3 border-t border-border">
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <div>
+              <span className="text-muted-foreground">Accuracy</span>
+              <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className={`h-full transition-all ${getProficiencyBarColor(proficiency.accuracyScore)}`}
+                  style={{ width: `${proficiency.accuracyScore}%` }}
+                />
+              </div>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Speed</span>
+              <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className={`h-full transition-all ${getProficiencyBarColor(proficiency.speedScore)}`}
+                  style={{ width: `${proficiency.speedScore}%` }}
+                />
+              </div>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Trend</span>
+              <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className={`h-full transition-all ${proficiency.trendScore >= 50 ? 'bg-success' : 'bg-error'}`}
+                  style={{ width: `${proficiency.trendScore}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Loading skeleton for the recommendations.
+ */
+function RecommendationsLoading() {
+  return (
+    <div className="space-y-3" aria-busy="true" aria-label="Loading recommendations">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="p-4 rounded-lg border-2 border-border bg-card animate-pulse"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-2">
+                <div className="h-4 w-6 bg-muted rounded" />
+                <div className="h-5 w-32 bg-muted rounded" />
+              </div>
+              <div className="h-5 w-24 bg-muted rounded mb-2" />
+              <div className="h-4 w-full bg-muted rounded" />
+            </div>
+            <div className="w-16">
+              <div className="h-8 w-12 bg-muted rounded mx-auto" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Empty state when no recommendations available.
+ */
+function EmptyRecommendations({ message }: { message: string }) {
+  return (
+    <div className="text-center py-8 px-4 rounded-lg border-2 border-dashed border-border">
+      <div className="text-4xl mb-3" aria-hidden="true">
+        📊
+      </div>
+      <p className="text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+/**
+ * MethodRecommendations component displays personalized practice recommendations
+ * based on the user's performance statistics.
+ */
+export function MethodRecommendations({
+  onSelectMethod,
+  className = '',
+}: MethodRecommendationsProps) {
+  const [analysis, setAnalysis] = useState<MethodAnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRecommendations = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const stats: UserStatistics = await getUserStatistics();
+      const result = analyzeMethodProficiency(stats);
+      setAnalysis(result);
+    } catch (err) {
+      setError('Failed to load recommendations. Please try again.');
+      console.error('Error loading recommendations:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRecommendations();
+  }, [loadRecommendations]);
+
+  const handleSelectMethod = useCallback(
+    (method: MethodName) => {
+      onSelectMethod(method);
+    },
+    [onSelectMethod]
+  );
+
+  return (
+    <Card variant="outlined" className={className}>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">
+              Recommended Practice
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              {analysis?.dataStatusMessage || 'Personalized suggestions based on your performance'}
+            </p>
+          </div>
+          {!loading && (
+            <button
+              onClick={loadRecommendations}
+              className="text-sm text-primary hover:text-primary/80 transition-colors
+                         focus:outline-none focus:underline"
+              aria-label="Refresh recommendations"
+            >
+              Refresh
+            </button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading && <RecommendationsLoading />}
+
+        {error && (
+          <div className="text-center py-4 px-4 rounded-lg bg-error/10 border border-error/20">
+            <p className="text-error">{error}</p>
+            <button
+              onClick={loadRecommendations}
+              className="mt-2 text-sm text-primary hover:underline"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && analysis && (
+          <>
+            {analysis.recommendations.length === 0 ? (
+              <EmptyRecommendations message={analysis.dataStatusMessage} />
+            ) : (
+              <div className="space-y-3">
+                {analysis.recommendations.map((rec) => (
+                  <RecommendationCard
+                    key={rec.method}
+                    recommendation={rec}
+                    onSelect={handleSelectMethod}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Overall proficiency overview */}
+            {analysis.hasEnoughData && (
+              <div className="mt-6 pt-4 border-t border-border">
+                <h4 className="text-sm font-semibold text-foreground mb-3">
+                  All Methods Overview
+                </h4>
+                <div className="space-y-2">
+                  {analysis.proficiencies
+                    .filter((p) => p.problemsSolved > 0)
+                    .sort((a, b) => b.overallScore - a.overallScore)
+                    .map((proficiency) => (
+                      <div
+                        key={proficiency.method}
+                        className="flex items-center gap-3"
+                      >
+                        <span className="text-sm text-muted-foreground w-36 truncate">
+                          {proficiency.displayName}
+                        </span>
+                        <div className="flex-1">
+                          <Progress
+                            value={proficiency.overallScore}
+                            max={100}
+                            className="h-2"
+                          />
+                        </div>
+                        <span
+                          className={`text-sm font-medium w-8 text-right ${getProficiencyColor(proficiency.overallScore)}`}
+                        >
+                          {proficiency.overallScore}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/practice/SessionConfig.tsx
+++ b/src/components/features/practice/SessionConfig.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { DifficultyLevel, type CustomRange } from '@/lib/types/problem';
 import { MethodName } from '@/lib/types/method';
@@ -8,6 +8,7 @@ import type { SessionConfig as SessionConfigType } from '@/lib/types/session';
 import { DifficultySelector } from './DifficultySelector';
 import { NumberRangeInput } from './NumberRangeInput';
 import { MethodSelector } from './MethodSelector';
+import { MethodRecommendations } from './MethodRecommendations';
 
 /**
  * Initial configuration values that can be passed from URL parameters.
@@ -74,6 +75,12 @@ export function SessionConfig({ onStartSession, initialValues }: SessionConfigPr
       setAllowNegatives(false);
     }
   };
+
+  // Handler for when a recommendation is selected
+  const handleSelectRecommendedMethod = useCallback((method: MethodName) => {
+    // Set only the recommended method as selected
+    setSelectedMethods([method]);
+  }, []);
 
   const handleStartSession = () => {
     const config: SessionConfigType = {
@@ -147,6 +154,12 @@ export function SessionConfig({ onStartSession, initialValues }: SessionConfigPr
           Customize your mental math training experience
         </p>
       </div>
+
+      {/* Method Recommendations - Based on user statistics */}
+      <MethodRecommendations
+        onSelectMethod={handleSelectRecommendedMethod}
+        className="mb-2"
+      />
 
       {/* Main configuration sections */}
       <div className="space-y-6">

--- a/src/components/features/practice/__tests__/MethodRecommendations.test.tsx
+++ b/src/components/features/practice/__tests__/MethodRecommendations.test.tsx
@@ -1,0 +1,451 @@
+/**
+ * Tests for MethodRecommendations component
+ * @module components/features/practice/__tests__/MethodRecommendations
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MethodRecommendations } from '../MethodRecommendations';
+import { MethodName } from '@/lib/types/method';
+import type { UserStatistics, CumulativeMethodStats } from '@/lib/types/statistics';
+
+// Mock the statistics store
+const mockGetUserStatistics = vi.fn();
+vi.mock('@/lib/storage/statistics-store', () => ({
+  getUserStatistics: () => mockGetUserStatistics(),
+}));
+
+/**
+ * Helper function to create mock CumulativeMethodStats.
+ */
+function createMockMethodStats(
+  overrides: Partial<CumulativeMethodStats> = {}
+): CumulativeMethodStats {
+  return {
+    method: MethodName.Distributive,
+    problemsSolved: 10,
+    correctAnswers: 8,
+    accuracy: 80,
+    averageTime: 12000,
+    trend: 'stable',
+    lastPracticed: new Date('2024-01-15'),
+    ...overrides,
+  };
+}
+
+/**
+ * Helper function to create mock UserStatistics.
+ */
+function createMockUserStats(
+  overrides: Partial<UserStatistics> = {}
+): UserStatistics {
+  return {
+    userId: 'test-user',
+    totalProblems: 50,
+    totalSessions: 5,
+    overallAccuracy: 75,
+    methodStatistics: {},
+    difficultyStatistics: {},
+    timeSeriesData: [],
+    weakAreas: [],
+    ...overrides,
+  };
+}
+
+describe('MethodRecommendations', () => {
+  const mockOnSelectMethod = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('should show loading skeleton while fetching data', async () => {
+      // Create a promise that doesn't resolve immediately
+      let resolvePromise: (value: UserStatistics) => void;
+      const statsPromise = new Promise<UserStatistics>((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockGetUserStatistics.mockReturnValue(statsPromise);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      // Should show loading state
+      expect(screen.getByLabelText(/loading recommendations/i)).toBeInTheDocument();
+
+      // Resolve the promise to clean up
+      resolvePromise!(createMockUserStats());
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/loading recommendations/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show message for new users with no statistics', async () => {
+      mockGetUserStatistics.mockResolvedValue(createMockUserStats());
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/start practicing/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('with recommendations', () => {
+    it('should display recommendations when user has practiced', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 90,
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+          [MethodName.Near100]: createMockMethodStats({
+            accuracy: 85,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        // Should show Squaring as a weak method recommendation (appears in both rec and overview)
+        const squaringElements = screen.getAllByText('Squaring');
+        expect(squaringElements.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('should call onSelectMethod when recommendation is clicked', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      // Wait for the recommendation button to appear
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /practice distributive method/i })
+        ).toBeInTheDocument();
+      });
+
+      // Click on the recommendation
+      const recButton = screen.getByRole('button', {
+        name: /practice distributive method/i,
+      });
+      fireEvent.click(recButton);
+
+      expect(mockOnSelectMethod).toHaveBeenCalledWith(MethodName.Distributive);
+    });
+
+    it('should display priority numbers', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 45,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('#1')).toBeInTheDocument();
+        expect(screen.getByText('#2')).toBeInTheDocument();
+      });
+    });
+
+    it('should display recommendation reasons', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Low Accuracy')).toBeInTheDocument();
+      });
+    });
+
+    it('should display proficiency score for methods with reliable data', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 50, // Low accuracy to ensure it appears as a recommendation
+            averageTime: 12000,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      // Wait for recommendations to load by checking for the heading
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: /recommended practice/i })
+        ).toBeInTheDocument();
+      });
+
+      // Wait a bit more for full render
+      await waitFor(() => {
+        // Score should be visible (appears in recommendations and overview)
+        const scoreElements = screen.getAllByText('score');
+        expect(scoreElements.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should have a refresh button', async () => {
+      mockGetUserStatistics.mockResolvedValue(createMockUserStats());
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /refresh recommendations/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should reload data when refresh button is clicked', async () => {
+      mockGetUserStatistics.mockResolvedValue(createMockUserStats());
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(mockGetUserStatistics).toHaveBeenCalledTimes(1);
+      });
+
+      // Click refresh
+      const refreshButton = screen.getByRole('button', {
+        name: /refresh recommendations/i,
+      });
+      fireEvent.click(refreshButton);
+
+      await waitFor(() => {
+        expect(mockGetUserStatistics).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should show error message when loading fails', async () => {
+      mockGetUserStatistics.mockRejectedValue(new Error('Network error'));
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load recommendations/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should have retry button when error occurs', async () => {
+      mockGetUserStatistics.mockRejectedValue(new Error('Network error'));
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should retry loading when retry button is clicked', async () => {
+      mockGetUserStatistics.mockRejectedValueOnce(new Error('Network error'));
+      mockGetUserStatistics.mockResolvedValueOnce(createMockUserStats());
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load recommendations/i)).toBeInTheDocument();
+      });
+
+      // Click retry
+      const retryButton = screen.getByRole('button', { name: /try again/i });
+      fireEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockGetUserStatistics).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('methods overview', () => {
+    it('should show all methods overview when user has enough data', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 90,
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 70,
+            problemsSolved: 20,
+          }),
+          [MethodName.Near100]: createMockMethodStats({
+            accuracy: 85,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('All Methods Overview')).toBeInTheDocument();
+      });
+    });
+
+    it('should display progress bars for practiced methods', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 90,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        // Check for progress bars (by role)
+        const progressBars = screen.getAllByRole('progressbar');
+        expect(progressBars.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have accessible labels on recommendation buttons', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        const recButton = screen.getByRole('button', {
+          name: /practice distributive method/i,
+        });
+        expect(recButton).toBeInTheDocument();
+      });
+    });
+
+    it('should have proper heading structure', async () => {
+      mockGetUserStatistics.mockResolvedValue(createMockUserStats());
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+          'Recommended Practice'
+        );
+      });
+    });
+  });
+
+  describe('className prop', () => {
+    it('should apply custom className', async () => {
+      mockGetUserStatistics.mockResolvedValue(createMockUserStats());
+
+      const { container } = render(
+        <MethodRecommendations
+          onSelectMethod={mockOnSelectMethod}
+          className="custom-class"
+        />
+      );
+
+      await waitFor(() => {
+        const card = container.firstChild as HTMLElement;
+        expect(card.classList.contains('custom-class')).toBe(true);
+      });
+    });
+  });
+
+  describe('declining trend highlighting', () => {
+    it('should prioritize declining methods in recommendations', async () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 70,
+            trend: 'declining',
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 50,
+            trend: 'stable',
+            problemsSolved: 20,
+          }),
+        },
+      });
+      mockGetUserStatistics.mockResolvedValue(stats);
+
+      render(<MethodRecommendations onSelectMethod={mockOnSelectMethod} />);
+
+      // Wait for recommendations to load
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /practice distributive method/i })
+        ).toBeInTheDocument();
+      });
+
+      // Declining method should have the "Declining Performance" badge
+      expect(screen.getByText('Declining Performance')).toBeInTheDocument();
+
+      // First recommendation (Priority 1) should be the declining one
+      const priorityLabel = screen.getByLabelText('Priority 1');
+      expect(priorityLabel.closest('button')).toHaveTextContent(
+        'Distributive Method'
+      );
+    });
+  });
+});

--- a/src/lib/core/analysis/__tests__/method-analyzer.test.ts
+++ b/src/lib/core/analysis/__tests__/method-analyzer.test.ts
@@ -1,0 +1,574 @@
+/**
+ * Tests for Method Analyzer
+ * @module core/analysis/__tests__/method-analyzer
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeMethodProficiency,
+  calculateMethodProficiency,
+  getMethodDisplayName,
+  getStrongestMethods,
+  getWeakestMethods,
+  createAnalyzerConfig,
+  defaultAnalyzerConfig,
+  type AnalyzerConfig,
+} from '../method-analyzer';
+import { MethodName } from '@/lib/types/method';
+import type { UserStatistics, CumulativeMethodStats } from '@/lib/types/statistics';
+
+/**
+ * Helper function to create mock CumulativeMethodStats.
+ */
+function createMockMethodStats(
+  overrides: Partial<CumulativeMethodStats> = {}
+): CumulativeMethodStats {
+  return {
+    method: MethodName.Distributive,
+    problemsSolved: 10,
+    correctAnswers: 8,
+    accuracy: 80,
+    averageTime: 12000,
+    trend: 'stable',
+    lastPracticed: new Date('2024-01-15'),
+    ...overrides,
+  };
+}
+
+/**
+ * Helper function to create mock UserStatistics.
+ */
+function createMockUserStats(
+  overrides: Partial<UserStatistics> = {}
+): UserStatistics {
+  return {
+    userId: 'test-user',
+    totalProblems: 50,
+    totalSessions: 5,
+    overallAccuracy: 75,
+    methodStatistics: {},
+    difficultyStatistics: {},
+    timeSeriesData: [],
+    weakAreas: [],
+    ...overrides,
+  };
+}
+
+describe('getMethodDisplayName', () => {
+  it('should return correct display names for all methods', () => {
+    expect(getMethodDisplayName(MethodName.Distributive)).toBe('Distributive Method');
+    expect(getMethodDisplayName(MethodName.NearPower10)).toBe('Near Power of 10');
+    expect(getMethodDisplayName(MethodName.DifferenceSquares)).toBe('Difference of Squares');
+    expect(getMethodDisplayName(MethodName.Factorization)).toBe('Factorization');
+    expect(getMethodDisplayName(MethodName.Squaring)).toBe('Squaring');
+    expect(getMethodDisplayName(MethodName.Near100)).toBe('Near 100');
+  });
+});
+
+describe('calculateMethodProficiency', () => {
+  describe('with no stats', () => {
+    it('should return zero scores for undefined stats', () => {
+      const proficiency = calculateMethodProficiency(MethodName.Distributive, undefined);
+
+      expect(proficiency.method).toBe(MethodName.Distributive);
+      expect(proficiency.displayName).toBe('Distributive Method');
+      expect(proficiency.overallScore).toBe(0);
+      expect(proficiency.accuracyScore).toBe(0);
+      expect(proficiency.speedScore).toBe(0);
+      expect(proficiency.trendScore).toBe(50); // Neutral
+      expect(proficiency.problemsSolved).toBe(0);
+      expect(proficiency.hasReliableData).toBe(false);
+      expect(proficiency.lastPracticed).toBeNull();
+    });
+  });
+
+  describe('with reliable stats', () => {
+    it('should calculate correct overall score with default weights', () => {
+      const stats = createMockMethodStats({
+        accuracy: 80,
+        averageTime: 15000, // Target time
+        trend: 'stable',
+        problemsSolved: 10,
+      });
+
+      const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+
+      // accuracy: 80 * 0.5 = 40
+      // speed: 100 * 0.3 = 30 (at target time)
+      // trend: 50 * 0.2 = 10
+      // total: 80
+      expect(proficiency.overallScore).toBe(80);
+      expect(proficiency.accuracyScore).toBe(80);
+      expect(proficiency.speedScore).toBe(100);
+      expect(proficiency.trendScore).toBe(50);
+      expect(proficiency.hasReliableData).toBe(true);
+    });
+
+    it('should calculate correct trend scores', () => {
+      const improvingStats = createMockMethodStats({ trend: 'improving' });
+      const stableStats = createMockMethodStats({ trend: 'stable' });
+      const decliningStats = createMockMethodStats({ trend: 'declining' });
+
+      expect(calculateMethodProficiency(MethodName.Distributive, improvingStats).trendScore).toBe(75);
+      expect(calculateMethodProficiency(MethodName.Distributive, stableStats).trendScore).toBe(50);
+      expect(calculateMethodProficiency(MethodName.Distributive, decliningStats).trendScore).toBe(25);
+    });
+
+    it('should calculate speed score based on target time', () => {
+      // At target time (15000ms)
+      const atTargetStats = createMockMethodStats({ averageTime: 15000 });
+      expect(calculateMethodProficiency(MethodName.Distributive, atTargetStats).speedScore).toBe(100);
+
+      // At double target time (30000ms)
+      const doubleStats = createMockMethodStats({ averageTime: 30000 });
+      expect(calculateMethodProficiency(MethodName.Distributive, doubleStats).speedScore).toBe(50);
+
+      // Faster than target (7500ms)
+      const fasterStats = createMockMethodStats({ averageTime: 7500 });
+      const fasterProficiency = calculateMethodProficiency(MethodName.Distributive, fasterStats);
+      // Speed would be 200% but capped at 100
+      expect(fasterProficiency.speedScore).toBe(100);
+    });
+
+    it('should respect minimum problems for reliable data', () => {
+      const insufficientStats = createMockMethodStats({ problemsSolved: 3 });
+      const sufficientStats = createMockMethodStats({ problemsSolved: 5 });
+
+      expect(calculateMethodProficiency(MethodName.Distributive, insufficientStats).hasReliableData).toBe(false);
+      expect(calculateMethodProficiency(MethodName.Distributive, sufficientStats).hasReliableData).toBe(true);
+    });
+
+    it('should include last practiced date', () => {
+      const date = new Date('2024-06-15');
+      const stats = createMockMethodStats({ lastPracticed: date });
+
+      const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+      expect(proficiency.lastPracticed).toEqual(date);
+    });
+  });
+
+  describe('with custom config', () => {
+    it('should use custom accuracy weight', () => {
+      const stats = createMockMethodStats({
+        accuracy: 100,
+        averageTime: 15000,
+        trend: 'stable',
+      });
+
+      const customConfig: AnalyzerConfig = {
+        ...defaultAnalyzerConfig,
+        accuracyWeight: 0.8,
+        speedWeight: 0.1,
+        trendWeight: 0.1,
+      };
+
+      const proficiency = calculateMethodProficiency(MethodName.Distributive, stats, customConfig);
+
+      // accuracy: 100 * 0.8 = 80
+      // speed: 100 * 0.1 = 10
+      // trend: 50 * 0.1 = 5
+      // total: 95
+      expect(proficiency.overallScore).toBe(95);
+    });
+
+    it('should use custom min problems threshold', () => {
+      const stats = createMockMethodStats({ problemsSolved: 8 });
+
+      const strictConfig: AnalyzerConfig = {
+        ...defaultAnalyzerConfig,
+        minProblemsForReliableScore: 10,
+      };
+
+      expect(calculateMethodProficiency(MethodName.Distributive, stats, strictConfig).hasReliableData).toBe(false);
+      expect(calculateMethodProficiency(MethodName.Distributive, stats).hasReliableData).toBe(true);
+    });
+  });
+});
+
+describe('analyzeMethodProficiency', () => {
+  describe('with no stats', () => {
+    it('should return empty proficiencies for new user', () => {
+      const stats = createMockUserStats();
+      const result = analyzeMethodProficiency(stats);
+
+      expect(result.proficiencies).toHaveLength(6); // All methods
+      expect(result.hasEnoughData).toBe(false);
+      expect(result.dataStatusMessage).toContain('Start practicing');
+    });
+
+    it('should recommend unpracticed methods', () => {
+      const stats = createMockUserStats();
+      const result = analyzeMethodProficiency(stats);
+
+      // Should recommend trying new methods
+      expect(result.recommendations.length).toBeGreaterThan(0);
+      expect(result.recommendations[0]?.reason).toBe('Not Yet Practiced');
+    });
+  });
+
+  describe('with partial stats', () => {
+    it('should identify methods with insufficient data', () => {
+      const stats = createMockUserStats({
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.Squaring]: createMockMethodStats({ problemsSolved: 2 }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+
+      expect(result.hasEnoughData).toBe(false);
+      expect(result.dataStatusMessage).toContain('at least');
+    });
+
+    it('should recommend methods with insufficient data after unpracticed methods', () => {
+      // When there are both unpracticed and insufficient-data methods,
+      // insufficient data methods should be recommended after unpracticed ones
+      const stats = createMockUserStats({
+        methodStatistics: {
+          // All other methods are unpracticed (not in methodStatistics)
+          // Distributive has insufficient data (3 problems, needs 5)
+          [MethodName.Distributive]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.Squaring]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.Near100]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.Factorization]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.NearPower10]: createMockMethodStats({ problemsSolved: 3 }),
+          [MethodName.DifferenceSquares]: createMockMethodStats({ problemsSolved: 3 }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+
+      // With all methods having insufficient data but practiced,
+      // they should be recommended with 'Limited Practice' reason
+      const limitedPracticeRecs = result.recommendations.filter(
+        r => r.reason === 'Limited Practice'
+      );
+      expect(limitedPracticeRecs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('with reliable stats', () => {
+    it('should identify weak methods', () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 90,
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 50,
+            problemsSolved: 20,
+          }),
+          [MethodName.Near100]: createMockMethodStats({
+            accuracy: 85,
+            problemsSolved: 20,
+          }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+
+      expect(result.hasEnoughData).toBe(true);
+
+      // Squaring should be recommended due to low accuracy
+      const squaringRec = result.recommendations.find(r => r.method === MethodName.Squaring);
+      expect(squaringRec).toBeDefined();
+      expect(squaringRec?.reason).toBe('Low Accuracy');
+    });
+
+    it('should prioritize declining methods', () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 60,
+            trend: 'declining',
+            problemsSolved: 20,
+          }),
+          [MethodName.Squaring]: createMockMethodStats({
+            accuracy: 50,
+            trend: 'stable',
+            problemsSolved: 20,
+          }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+
+      // Declining should be first priority
+      expect(result.recommendations[0]?.method).toBe(MethodName.Distributive);
+      expect(result.recommendations[0]?.reason).toBe('Declining Performance');
+    });
+
+    it('should identify methods needing speed improvement', () => {
+      const stats = createMockUserStats({
+        totalProblems: 100,
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({
+            accuracy: 90,
+            averageTime: 45000, // 3x target
+            problemsSolved: 20,
+          }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+      const distRec = result.recommendations.find(r => r.method === MethodName.Distributive);
+
+      expect(distRec).toBeDefined();
+      expect(distRec?.reason).toBe('Needs Speed Improvement');
+    });
+
+    it('should respect max recommendations config', () => {
+      const stats = createMockUserStats({
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({ accuracy: 50 }),
+          [MethodName.Squaring]: createMockMethodStats({ accuracy: 45 }),
+          [MethodName.Near100]: createMockMethodStats({ accuracy: 40 }),
+          [MethodName.Factorization]: createMockMethodStats({ accuracy: 55 }),
+        },
+      });
+
+      const config = createAnalyzerConfig({ maxRecommendations: 2 });
+      const result = analyzeMethodProficiency(stats, config);
+
+      expect(result.recommendations.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should order recommendations by priority', () => {
+      const stats = createMockUserStats({
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats({ accuracy: 50 }),
+          [MethodName.Squaring]: createMockMethodStats({ accuracy: 45 }),
+          [MethodName.Near100]: createMockMethodStats({ accuracy: 40 }),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+
+      for (let i = 1; i < result.recommendations.length; i++) {
+        expect(result.recommendations[i]!.priority).toBeGreaterThan(
+          result.recommendations[i - 1]!.priority
+        );
+      }
+    });
+  });
+
+  describe('proficiencies calculation', () => {
+    it('should include all six methods in proficiencies', () => {
+      const stats = createMockUserStats();
+      const result = analyzeMethodProficiency(stats);
+
+      const methodNames = result.proficiencies.map(p => p.method);
+      expect(methodNames).toContain(MethodName.Distributive);
+      expect(methodNames).toContain(MethodName.NearPower10);
+      expect(methodNames).toContain(MethodName.DifferenceSquares);
+      expect(methodNames).toContain(MethodName.Factorization);
+      expect(methodNames).toContain(MethodName.Squaring);
+      expect(methodNames).toContain(MethodName.Near100);
+    });
+
+    it('should include display names in proficiencies', () => {
+      const stats = createMockUserStats({
+        methodStatistics: {
+          [MethodName.Distributive]: createMockMethodStats(),
+        },
+      });
+
+      const result = analyzeMethodProficiency(stats);
+      const distProf = result.proficiencies.find(p => p.method === MethodName.Distributive);
+
+      expect(distProf?.displayName).toBe('Distributive Method');
+    });
+  });
+});
+
+describe('getStrongestMethods', () => {
+  it('should return strongest methods sorted by score', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats({ accuracy: 90 }),
+        [MethodName.Squaring]: createMockMethodStats({ accuracy: 70 }),
+        [MethodName.Near100]: createMockMethodStats({ accuracy: 95 }),
+      },
+    });
+
+    const strongest = getStrongestMethods(stats, 2);
+
+    expect(strongest.length).toBe(2);
+    expect(strongest[0]?.method).toBe(MethodName.Near100);
+    expect(strongest[1]?.method).toBe(MethodName.Distributive);
+  });
+
+  it('should only include methods with reliable data', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats({
+          accuracy: 95,
+          problemsSolved: 2, // Not reliable
+        }),
+        [MethodName.Squaring]: createMockMethodStats({
+          accuracy: 70,
+          problemsSolved: 10, // Reliable
+        }),
+      },
+    });
+
+    const strongest = getStrongestMethods(stats);
+
+    expect(strongest.length).toBe(1);
+    expect(strongest[0]?.method).toBe(MethodName.Squaring);
+  });
+
+  it('should return empty array when no reliable data', () => {
+    const stats = createMockUserStats();
+    const strongest = getStrongestMethods(stats);
+
+    expect(strongest).toHaveLength(0);
+  });
+});
+
+describe('getWeakestMethods', () => {
+  it('should return weakest methods sorted by score (ascending)', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats({ accuracy: 90 }),
+        [MethodName.Squaring]: createMockMethodStats({ accuracy: 70 }),
+        [MethodName.Near100]: createMockMethodStats({ accuracy: 50 }),
+      },
+    });
+
+    const weakest = getWeakestMethods(stats, 2);
+
+    expect(weakest.length).toBe(2);
+    expect(weakest[0]?.method).toBe(MethodName.Near100);
+    expect(weakest[1]?.method).toBe(MethodName.Squaring);
+  });
+
+  it('should only include methods with reliable data', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats({
+          accuracy: 30,
+          problemsSolved: 2, // Not reliable
+        }),
+        [MethodName.Squaring]: createMockMethodStats({
+          accuracy: 70,
+          problemsSolved: 10, // Reliable
+        }),
+      },
+    });
+
+    const weakest = getWeakestMethods(stats);
+
+    expect(weakest.length).toBe(1);
+    expect(weakest[0]?.method).toBe(MethodName.Squaring);
+  });
+});
+
+describe('createAnalyzerConfig', () => {
+  it('should return default config when no overrides', () => {
+    const config = createAnalyzerConfig();
+
+    expect(config).toEqual(defaultAnalyzerConfig);
+  });
+
+  it('should override specific values', () => {
+    const config = createAnalyzerConfig({
+      minProblemsForReliableScore: 10,
+      maxRecommendations: 5,
+    });
+
+    expect(config.minProblemsForReliableScore).toBe(10);
+    expect(config.maxRecommendations).toBe(5);
+    expect(config.accuracyWeight).toBe(defaultAnalyzerConfig.accuracyWeight);
+  });
+});
+
+describe('defaultAnalyzerConfig', () => {
+  it('should have valid weight values that sum to 1', () => {
+    const totalWeight =
+      defaultAnalyzerConfig.accuracyWeight +
+      defaultAnalyzerConfig.speedWeight +
+      defaultAnalyzerConfig.trendWeight;
+
+    expect(totalWeight).toBeCloseTo(1, 5);
+  });
+
+  it('should have reasonable default values', () => {
+    expect(defaultAnalyzerConfig.minProblemsForReliableScore).toBeGreaterThan(0);
+    expect(defaultAnalyzerConfig.maxRecommendations).toBeGreaterThan(0);
+    expect(defaultAnalyzerConfig.targetAverageTimeMs).toBeGreaterThan(0);
+    expect(defaultAnalyzerConfig.weaknessThreshold).toBeGreaterThan(0);
+    expect(defaultAnalyzerConfig.weaknessThreshold).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('edge cases', () => {
+  it('should handle very high accuracy values', () => {
+    const stats = createMockMethodStats({ accuracy: 100 });
+    const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+
+    expect(proficiency.accuracyScore).toBe(100);
+  });
+
+  it('should handle zero accuracy', () => {
+    const stats = createMockMethodStats({ accuracy: 0 });
+    const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+
+    expect(proficiency.accuracyScore).toBe(0);
+  });
+
+  it('should handle very slow average time', () => {
+    const stats = createMockMethodStats({ averageTime: 300000 }); // 5 minutes
+    const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+
+    expect(proficiency.speedScore).toBeGreaterThanOrEqual(0);
+    expect(proficiency.speedScore).toBeLessThan(20);
+  });
+
+  it('should handle very fast average time', () => {
+    const stats = createMockMethodStats({ averageTime: 1000 }); // 1 second
+    const proficiency = calculateMethodProficiency(MethodName.Distributive, stats);
+
+    expect(proficiency.speedScore).toBe(100); // Capped
+  });
+
+  it('should handle user with all methods practiced', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats(),
+        [MethodName.NearPower10]: createMockMethodStats(),
+        [MethodName.DifferenceSquares]: createMockMethodStats(),
+        [MethodName.Factorization]: createMockMethodStats(),
+        [MethodName.Squaring]: createMockMethodStats(),
+        [MethodName.Near100]: createMockMethodStats(),
+      },
+    });
+
+    const result = analyzeMethodProficiency(stats);
+
+    expect(result.proficiencies.length).toBe(6);
+    expect(result.proficiencies.every(p => p.problemsSolved > 0)).toBe(true);
+  });
+
+  it('should handle user with perfect performance', () => {
+    const stats = createMockUserStats({
+      methodStatistics: {
+        [MethodName.Distributive]: createMockMethodStats({
+          accuracy: 100,
+          averageTime: 5000,
+          trend: 'improving',
+          problemsSolved: 50,
+        }),
+      },
+    });
+
+    const result = analyzeMethodProficiency(stats);
+    const distProf = result.proficiencies.find(p => p.method === MethodName.Distributive);
+
+    expect(distProf?.overallScore).toBeGreaterThanOrEqual(90);
+  });
+});

--- a/src/lib/core/analysis/index.ts
+++ b/src/lib/core/analysis/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Analysis module - Tools for analyzing user statistics and generating recommendations.
+ * @module core/analysis
+ */
+
+export {
+  analyzeMethodProficiency,
+  calculateMethodProficiency,
+  getMethodDisplayName,
+  getStrongestMethods,
+  getWeakestMethods,
+  createAnalyzerConfig,
+  defaultAnalyzerConfig,
+  type MethodProficiency,
+  type MethodRecommendation,
+  type MethodAnalysisResult,
+  type AnalyzerConfig,
+} from './method-analyzer';

--- a/src/lib/core/analysis/method-analyzer.ts
+++ b/src/lib/core/analysis/method-analyzer.ts
@@ -1,0 +1,416 @@
+/**
+ * Method Analyzer - Analyzes user statistics to identify weak methods
+ * and generate personalized practice recommendations.
+ * @module core/analysis/method-analyzer
+ */
+
+import type { UserStatistics, CumulativeMethodStats } from '@/lib/types/statistics';
+import { MethodName } from '@/lib/types/method';
+
+/**
+ * Proficiency score for a single method, including components and overall score.
+ */
+export interface MethodProficiency {
+  /** The method being evaluated */
+  method: MethodName;
+  /** Display name for the method */
+  displayName: string;
+  /** Overall proficiency score (0-100, higher is better) */
+  overallScore: number;
+  /** Accuracy component score (0-100) */
+  accuracyScore: number;
+  /** Speed component score (0-100) */
+  speedScore: number;
+  /** Trend component score (0-100) - higher means improving */
+  trendScore: number;
+  /** Number of problems solved with this method */
+  problemsSolved: number;
+  /** Whether there's enough data for a reliable score */
+  hasReliableData: boolean;
+  /** When the method was last practiced */
+  lastPracticed: Date | null;
+}
+
+/**
+ * A recommendation for practice.
+ */
+export interface MethodRecommendation {
+  /** The recommended method */
+  method: MethodName;
+  /** Display name for the method */
+  displayName: string;
+  /** Priority level (1 = highest priority) */
+  priority: number;
+  /** Reason for the recommendation */
+  reason: string;
+  /** Detailed explanation for the user */
+  explanation: string;
+  /** The proficiency score that led to this recommendation */
+  proficiency: MethodProficiency;
+}
+
+/**
+ * Result of analyzing all methods for a user.
+ */
+export interface MethodAnalysisResult {
+  /** Proficiency scores for all methods with data */
+  proficiencies: MethodProficiency[];
+  /** Recommended methods for focused practice (ordered by priority) */
+  recommendations: MethodRecommendation[];
+  /** Whether the user has enough data for meaningful recommendations */
+  hasEnoughData: boolean;
+  /** Message to display if not enough data */
+  dataStatusMessage: string;
+}
+
+/**
+ * Configuration for the analyzer.
+ */
+export interface AnalyzerConfig {
+  /** Minimum problems needed for reliable scoring */
+  minProblemsForReliableScore: number;
+  /** Weight for accuracy in overall score (0-1) */
+  accuracyWeight: number;
+  /** Weight for speed in overall score (0-1) */
+  speedWeight: number;
+  /** Weight for trend in overall score (0-1) */
+  trendWeight: number;
+  /** Target average time in ms (used for speed scoring) */
+  targetAverageTimeMs: number;
+  /** Maximum recommendations to return */
+  maxRecommendations: number;
+  /** Threshold below which a method is considered weak (0-100) */
+  weaknessThreshold: number;
+}
+
+/**
+ * Default configuration for the analyzer.
+ */
+const DEFAULT_CONFIG: AnalyzerConfig = {
+  minProblemsForReliableScore: 5,
+  accuracyWeight: 0.5,
+  speedWeight: 0.3,
+  trendWeight: 0.2,
+  targetAverageTimeMs: 15000, // 15 seconds target
+  maxRecommendations: 3,
+  weaknessThreshold: 70,
+};
+
+/**
+ * Display names for methods.
+ */
+const METHOD_DISPLAY_NAMES: Record<MethodName, string> = {
+  [MethodName.Distributive]: 'Distributive Method',
+  [MethodName.NearPower10]: 'Near Power of 10',
+  [MethodName.DifferenceSquares]: 'Difference of Squares',
+  [MethodName.Factorization]: 'Factorization',
+  [MethodName.Squaring]: 'Squaring',
+  [MethodName.Near100]: 'Near 100',
+};
+
+/**
+ * Get display name for a method.
+ */
+export function getMethodDisplayName(method: MethodName): string {
+  return METHOD_DISPLAY_NAMES[method];
+}
+
+/**
+ * Calculate the proficiency score for a single method.
+ */
+export function calculateMethodProficiency(
+  method: MethodName,
+  stats: CumulativeMethodStats | undefined,
+  config: AnalyzerConfig = DEFAULT_CONFIG
+): MethodProficiency {
+  const displayName = getMethodDisplayName(method);
+
+  // No data for this method
+  if (!stats) {
+    return {
+      method,
+      displayName,
+      overallScore: 0,
+      accuracyScore: 0,
+      speedScore: 0,
+      trendScore: 50, // Neutral trend
+      problemsSolved: 0,
+      hasReliableData: false,
+      lastPracticed: null,
+    };
+  }
+
+  const hasReliableData = stats.problemsSolved >= config.minProblemsForReliableScore;
+
+  // Calculate accuracy score (0-100)
+  // Accuracy is already 0-100
+  const accuracyScore = Math.min(100, Math.max(0, stats.accuracy));
+
+  // Calculate speed score (0-100)
+  // Score of 100 for hitting target time, decreasing as time increases
+  // Score scales: at 2x target time = 50, at 3x = 33, etc.
+  const speedRatio = config.targetAverageTimeMs / Math.max(stats.averageTime, 1000);
+  const speedScore = Math.min(100, Math.max(0, speedRatio * 100));
+
+  // Calculate trend score (0-100)
+  // 50 = stable, >50 = improving, <50 = declining
+  let trendScore: number;
+  switch (stats.trend) {
+    case 'improving':
+      trendScore = 75;
+      break;
+    case 'declining':
+      trendScore = 25;
+      break;
+    case 'stable':
+    default:
+      trendScore = 50;
+      break;
+  }
+
+  // Calculate overall score (weighted average)
+  const overallScore = Math.round(
+    config.accuracyWeight * accuracyScore +
+      config.speedWeight * speedScore +
+      config.trendWeight * trendScore
+  );
+
+  return {
+    method,
+    displayName,
+    overallScore,
+    accuracyScore: Math.round(accuracyScore),
+    speedScore: Math.round(speedScore),
+    trendScore,
+    problemsSolved: stats.problemsSolved,
+    hasReliableData,
+    lastPracticed: stats.lastPracticed ? new Date(stats.lastPracticed) : null,
+  };
+}
+
+/**
+ * Generate a recommendation reason based on proficiency analysis.
+ */
+function generateRecommendationReason(proficiency: MethodProficiency): {
+  reason: string;
+  explanation: string;
+} {
+  const { accuracyScore, speedScore, trendScore, hasReliableData, problemsSolved } = proficiency;
+
+  // Not enough data
+  if (!hasReliableData) {
+    return {
+      reason: 'Limited Practice',
+      explanation: `You've only practiced ${problemsSolved} problem${problemsSolved === 1 ? '' : 's'} with this method. More practice will help build proficiency.`,
+    };
+  }
+
+  // Declining trend is priority concern
+  if (trendScore < 40) {
+    return {
+      reason: 'Declining Performance',
+      explanation:
+        'Your recent performance with this method has been declining. Some focused practice can help turn this around.',
+    };
+  }
+
+  // Low accuracy is the main issue
+  if (accuracyScore < 70) {
+    return {
+      reason: 'Low Accuracy',
+      explanation: `Your accuracy is ${accuracyScore}% for this method. Focus on understanding the steps rather than speed.`,
+    };
+  }
+
+  // Slow but accurate
+  if (speedScore < 50 && accuracyScore >= 70) {
+    return {
+      reason: 'Needs Speed Improvement',
+      explanation:
+        'You understand this method well but are taking longer than optimal. Practice will help build speed.',
+    };
+  }
+
+  // General weakness
+  return {
+    reason: 'Needs Practice',
+    explanation:
+      'This method has room for improvement. Regular practice will strengthen your skills.',
+  };
+}
+
+/**
+ * Analyze user statistics and generate method recommendations.
+ */
+export function analyzeMethodProficiency(
+  stats: UserStatistics,
+  config: AnalyzerConfig = DEFAULT_CONFIG
+): MethodAnalysisResult {
+  // Calculate proficiency for all methods
+  const allMethods = Object.values(MethodName);
+  const proficiencies: MethodProficiency[] = allMethods.map((method) =>
+    calculateMethodProficiency(method, stats.methodStatistics[method], config)
+  );
+
+  // Check if we have enough data overall
+  const methodsWithData = proficiencies.filter((p) => p.problemsSolved > 0);
+  const methodsWithReliableData = proficiencies.filter((p) => p.hasReliableData);
+
+  // Determine data status
+  let hasEnoughData = false;
+  let dataStatusMessage = '';
+
+  if (methodsWithData.length === 0) {
+    dataStatusMessage = 'Start practicing to get personalized recommendations!';
+  } else if (methodsWithReliableData.length === 0) {
+    dataStatusMessage = `Practice at least ${config.minProblemsForReliableScore} problems per method for accurate recommendations.`;
+    hasEnoughData = false;
+  } else {
+    hasEnoughData = true;
+    dataStatusMessage = `Based on ${stats.totalProblems} problems across ${methodsWithData.length} methods.`;
+  }
+
+  // Generate recommendations
+  const recommendations: MethodRecommendation[] = [];
+
+  // Priority 1: Methods with declining trends
+  const decliningMethods = proficiencies
+    .filter((p) => p.hasReliableData && p.trendScore < 40)
+    .sort((a, b) => a.trendScore - b.trendScore);
+
+  // Priority 2: Methods with low overall scores
+  const weakMethods = proficiencies
+    .filter(
+      (p) =>
+        p.hasReliableData &&
+        p.overallScore < config.weaknessThreshold &&
+        !decliningMethods.some((d) => d.method === p.method)
+    )
+    .sort((a, b) => a.overallScore - b.overallScore);
+
+  // Priority 3: Methods never practiced
+  const unpracticedMethods = proficiencies.filter((p) => p.problemsSolved === 0);
+
+  // Priority 4: Methods with insufficient data
+  const insufficientDataMethods = proficiencies.filter(
+    (p) =>
+      p.problemsSolved > 0 &&
+      !p.hasReliableData &&
+      !unpracticedMethods.some((u) => u.method === p.method)
+  );
+
+  // Build recommendations list
+  let priority = 1;
+
+  // Add declining methods
+  for (const proficiency of decliningMethods) {
+    if (recommendations.length >= config.maxRecommendations) break;
+    const { reason, explanation } = generateRecommendationReason(proficiency);
+    recommendations.push({
+      method: proficiency.method,
+      displayName: proficiency.displayName,
+      priority: priority++,
+      reason,
+      explanation,
+      proficiency,
+    });
+  }
+
+  // Add weak methods
+  for (const proficiency of weakMethods) {
+    if (recommendations.length >= config.maxRecommendations) break;
+    const { reason, explanation } = generateRecommendationReason(proficiency);
+    recommendations.push({
+      method: proficiency.method,
+      displayName: proficiency.displayName,
+      priority: priority++,
+      reason,
+      explanation,
+      proficiency,
+    });
+  }
+
+  // Add unpracticed methods (if no other recommendations)
+  if (recommendations.length < config.maxRecommendations) {
+    for (const proficiency of unpracticedMethods) {
+      if (recommendations.length >= config.maxRecommendations) break;
+      recommendations.push({
+        method: proficiency.method,
+        displayName: proficiency.displayName,
+        priority: priority++,
+        reason: 'Not Yet Practiced',
+        explanation: "You haven't tried this method yet. Give it a go!",
+        proficiency,
+      });
+    }
+  }
+
+  // Add insufficient data methods
+  if (recommendations.length < config.maxRecommendations) {
+    for (const proficiency of insufficientDataMethods) {
+      if (recommendations.length >= config.maxRecommendations) break;
+      const { reason, explanation } = generateRecommendationReason(proficiency);
+      recommendations.push({
+        method: proficiency.method,
+        displayName: proficiency.displayName,
+        priority: priority++,
+        reason,
+        explanation,
+        proficiency,
+      });
+    }
+  }
+
+  return {
+    proficiencies,
+    recommendations,
+    hasEnoughData,
+    dataStatusMessage,
+  };
+}
+
+/**
+ * Get the strongest methods for a user.
+ */
+export function getStrongestMethods(
+  stats: UserStatistics,
+  count: number = 3,
+  config: AnalyzerConfig = DEFAULT_CONFIG
+): MethodProficiency[] {
+  const result = analyzeMethodProficiency(stats, config);
+
+  return result.proficiencies
+    .filter((p) => p.hasReliableData)
+    .sort((a, b) => b.overallScore - a.overallScore)
+    .slice(0, count);
+}
+
+/**
+ * Get the weakest methods for a user.
+ */
+export function getWeakestMethods(
+  stats: UserStatistics,
+  count: number = 3,
+  config: AnalyzerConfig = DEFAULT_CONFIG
+): MethodProficiency[] {
+  const result = analyzeMethodProficiency(stats, config);
+
+  return result.proficiencies
+    .filter((p) => p.hasReliableData)
+    .sort((a, b) => a.overallScore - b.overallScore)
+    .slice(0, count);
+}
+
+/**
+ * Create a custom analyzer configuration.
+ */
+export function createAnalyzerConfig(
+  overrides: Partial<AnalyzerConfig> = {}
+): AnalyzerConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides,
+  };
+}
+
+export { DEFAULT_CONFIG as defaultAnalyzerConfig };


### PR DESCRIPTION
## Summary

- Add MethodAnalyzer utility for calculating method proficiency scores
- Create MethodRecommendations component to display personalized practice suggestions
- Integrate recommendations into the practice configuration page
- Allow users to click recommendations to start focused practice on weak methods

## Implementation Details

### Proficiency Scoring
The analyzer calculates a composite score (0-100) for each method based on:
- **Accuracy** (50% weight): Direct mapping from user's accuracy percentage
- **Speed** (30% weight): Ratio of target time to actual average time
- **Trend** (20% weight): Recent performance direction (improving/stable/declining)

### Recommendation Priority
Methods are recommended in the following priority order:
1. Methods with declining performance trends
2. Methods with low overall scores (below 70)
3. Methods the user hasn't practiced yet
4. Methods with insufficient data for reliable scoring

### Features
- Loading skeleton while fetching statistics
- Error state with retry functionality
- Refresh button to reload recommendations
- All methods overview with progress bars
- Accessible labels and proper heading structure
- Clicking a recommendation pre-selects that method for practice

## Test Plan
- [x] MethodAnalyzer unit tests (35 tests)
  - Proficiency calculation with various inputs
  - Trend scoring (improving/stable/declining)
  - Speed scoring relative to target time
  - Recommendation generation and prioritization
  - Edge cases (zero data, perfect scores, etc.)
- [x] MethodRecommendations component tests (18 tests)
  - Loading state display
  - Empty state for new users
  - Recommendation click handling
  - Error state and retry
  - Accessibility labels
  - Priority ordering verification
- [x] Build verification passes
- [x] All 53 new tests pass

Closes #71